### PR TITLE
Wasp Lisp port is now at OS Kernel 21.1

### DIFF
--- a/data.js
+++ b/data.js
@@ -65,7 +65,7 @@ var ports = [
     {
         platform: "Wasp Lisp",
         url: "https://github.com/doublec/shen-wasp",
-        kernel: "21.0",
+        kernel: "21.1",
         certified: true
     },
     {


### PR DESCRIPTION
Updates version of Wasp Lisp port to OS Kernel 21.1.