### PR TITLE
Updated Wasp Lisp kernel version to 22.0

### DIFF
--- a/data.js
+++ b/data.js
@@ -73,7 +73,7 @@ var ports = [
   {
     platform: "Wasp Lisp",
     github: "doublec/shen-wasp",
-    kernel: "21.1",
+    kernel: "22.0",
     certified: true
   },
   {


### PR DESCRIPTION
Changes version number of Wasp Lisp to OS kernel 22.0.