### PR TITLE
Add shen-go bytecode VM port (Go, kernel 41.1)

### DIFF
--- a/data.shen
+++ b/data.shen
@@ -39,6 +39,13 @@
     "certified" true
   })
   ({
+    "name"      "shen-go (bytecode VM)"
+    "platform"  "Go"
+    "github"    "pyrex41/shen-go"
+    "kernel"    "41.1"
+    "certified" true
+  })
+  ({
     "platform"  "Haskell"
     "github"    "mthom/shentong"
     "kernel"    "20.0"

--- a/index.html
+++ b/index.html
@@ -147,6 +147,10 @@
               <td><a href="https://github.com/tizoc/shen-scheme">tizoc/shen-scheme</a></td>
             </tr>
             <tr>
+              <td>Go</td>
+              <td><a href="https://github.com/pyrex41/shen-go">pyrex41/shen-go</a> (bytecode VM, kernel 41.1) &mdash; fork of <a href="https://github.com/tiancaiamao/shen-go">tiancaiamao/shen-go</a></td>
+            </tr>
+            <tr>
               <th colspan="2">Inactive Ports</th>
             </tr>
             <tr>


### PR DESCRIPTION
## What this is

**`pyrex41/shen-go` is a fork of the existing `tiancaiamao/shen-go` port**
(already listed as the certified Go entry). It is not an independent
reimplementation — it tracks that port and adds two things on top of it:
a bytecode VM and a newer kernel. I've added it as a separate Go row
(rather than editing the upstream entry) and disambiguated it by name.

## How it differs from `tiancaiamao/shen-go`

**1. Bytecode VM compiler for KL (the main change).**
Upstream evaluates every user-defined function with a KL tree-walking
interpreter (alist environments, per-call cons allocation, special-form
re-dispatch on every node). This fork compiles each `defun` once, at
define time, to a flat bytecode sequence:

- variables become integer-indexed slots in a per-call frame — variable
  lookup goes from an O(depth) alist scan to an O(1) array read, and the
  per-call environment cons allocation is eliminated;
- special forms (`if`/`let`/`cond`/`and`/`or`/`do`/`lambda`/`freeze`/
  `trap-error`) are lowered at compile time; the VM loop is a single
  `switch` over `uint8` opcodes;
- closures capture upvalues by value at creation time (no alist chain);
- self-tail calls loop in place without growing the Go stack; other tail
  calls reuse the existing trampoline;
- `+ - * < <= > >= = not` have fixnum fast-path opcodes.

Both REPL/KL `defun` and Shen-level `define` (which lowers to `defun`)
are compiled. Measured vs the upstream tree-walker: ~15× faster
`tak(18,12,6)`, ~60× faster tight tail-recursive integer loops.

**2. Kernel upgraded 39.2 → S41.1.**
Upstream's current entry shows 21.0 (it's actually on 39.2 now); this
fork bundles the regenerated S41.1 kernel.

## Certification

Passes the official kernel suite (`tests/runme.shen` →
`harness.shen` + `kerneltests.shen` from ShenOSKernel-41.1) **100%**:
all **35** report sections, **134** assertions passed, **0** failed, no
errors/panics — hence the `certified` flag.

Both changes are also offered back upstream (tiancaiamao/shen-go PRs #50
for the VM and #51 for the 41.1 kernel); if they land, this entry can be
folded back into the upstream one.
