### PR TITLE
Add shen-lua port (LuaJIT, kernel 41.1)

### DIFF
--- a/data.shen
+++ b/data.shen
@@ -58,6 +58,12 @@
     "certified" true
   })
   ({
+    "platform"  "Lua"
+    "github"    "pyrex41/shen-lua"
+    "kernel"    "41.1"
+    "certified" true
+  })
+  ({
     "platform"  "Ruby"
     "github"    "gregspurrier/shen-ruby"
     "kernel"    "19.1"

--- a/index.html
+++ b/index.html
@@ -151,6 +151,10 @@
               <td><a href="https://github.com/pyrex41/shen-go">pyrex41/shen-go</a> (bytecode VM, kernel 41.1) &mdash; fork of <a href="https://github.com/tiancaiamao/shen-go">tiancaiamao/shen-go</a></td>
             </tr>
             <tr>
+              <td>Lua</td>
+              <td><a href="https://github.com/pyrex41/shen-lua">pyrex41/shen-lua</a> (LuaJIT, kernel 41.1)</td>
+            </tr>
+            <tr>
               <th colspan="2">Inactive Ports</th>
             </tr>
             <tr>


### PR DESCRIPTION
Adds [pyrex41/shen-lua](https://github.com/pyrex41/shen-lua) to the ports table — a port of Shen to Lua, certified against kernel 41.1.

**About the port:** KLambda compiles to Lua source, which LuaJIT trace-compiles to machine code. It passes the official 41.1 kernel test suite (vendored in the repo, so certification is verifiable from a clone): 134/134 assertions across all 35 report sections, under both its native Prolog/typecheck engine and the plain compiled-KL path. It also runs on plain PUC Lua 5.1/5.4/5.5 (134/134, with the FFI engine and caches feature-detected off).

Beyond certification: a `require("shen")` embedding API with bidirectional typed Lua↔Shen interop, a single-file bundle (~6 MB, boots in ~70 ms), luarocks packaging (`luarocks install shen`), and an [executable walkthrough](https://github.com/pyrex41/shen-lua/blob/main/demo/walkthrough.md) whose code blocks re-run and verify.

Same shape as the shen-go addition (#10): one entry in `data.shen`, one row under Active Ports in the static `index.html` table.