### PR TITLE
Add shen-rust port (Rust, kernel 41.1)

### DIFF
--- a/data.shen
+++ b/data.shen
@@ -70,6 +70,12 @@
     "certified" true
   })
   ({
+    "platform"  "Rust"
+    "github"    "pyrex41/shen-rust"
+    "kernel"    "41.1"
+    "certified" true
+  })
+  ({
     "platform"  "Scheme"
     "github"    "tizoc/shen-scheme"
     "kernel"    "22.2"

--- a/data.shen
+++ b/data.shen
@@ -58,6 +58,12 @@
     "certified" true
   })
   ({
+    "platform"  "Lua"
+    "github"    "pyrex41/shen-lua"
+    "kernel"    "41.1"
+    "certified" true
+  })
+  ({
     "platform"  "Ruby"
     "github"    "gregspurrier/shen-ruby"
     "kernel"    "19.1"

--- a/index.html
+++ b/index.html
@@ -151,6 +151,10 @@
               <td><a href="https://github.com/pyrex41/shen-go">pyrex41/shen-go</a> (bytecode VM, kernel 41.1) &mdash; fork of <a href="https://github.com/tiancaiamao/shen-go">tiancaiamao/shen-go</a></td>
             </tr>
             <tr>
+              <td>Lua</td>
+              <td><a href="https://github.com/pyrex41/shen-lua">pyrex41/shen-lua</a> (LuaJIT, kernel 41.1)</td>
+            </tr>
+            <tr>
               <th colspan="2">Inactive Ports</th>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -155,6 +155,10 @@
               <td><a href="https://github.com/pyrex41/shen-lua">pyrex41/shen-lua</a> (LuaJIT, kernel 41.1)</td>
             </tr>
             <tr>
+              <td>Rust</td>
+              <td><a href="https://github.com/pyrex41/shen-rust">pyrex41/shen-rust</a> (tree-walker + bytecode VM + AOT-compiled kernel, kernel 41.1)</td>
+            </tr>
+            <tr>
               <th colspan="2">Inactive Ports</th>
             </tr>
             <tr>


### PR DESCRIPTION
## What this is

`pyrex41/shen-rust` is an independent port of Shen to Rust (not a fork of
an existing port). It boots the upstream **ShenOSKernel-41.1** and passes
the full kernel conformance suite — **134/134 tests** — in every execution
mode, run via `cargo run --release --bin shen-rust -- --kernel-tests`.

Added as a certified Rust row in `data.shen` (alphabetical, between Ruby
and Scheme) and to the Active Ports table in `index.html`, following the
same shape as the recent shen-go / shen-lua additions.

## About the port

- **Tiered engine**: tree-walking interpreter (default), the 21 kernel
  KLambda files AOT-compiled to Rust at build time, a bytecode VM for
  load-once/serve-many processes, and an opt-in per-file AOT overlay.
  Every tier is differentially tested against the tree-walker at 134/0.
- **Memory**: values are word-sized tagged words over a non-moving
  mark-sweep GC (collection opt-in; grow-only default).
- **Extras**: AWS Cedar authorization embedded as first-class `cedar.*`
  Shen values, and a small compiler that turns Shen sequent-calculus
  specs into Rust guard types.
- Docs include an executable, re-verifiable tour
  ([DEMO.md](https://github.com/pyrex41/shen-rust/blob/main/DEMO.md)) and
  honest benchmarks vs shen-cl
  ([PERFORMANCE.md](https://github.com/pyrex41/shen-rust/blob/main/PERFORMANCE.md)).

BSD-3-Clause, with the vendored kernel retaining Mark Tarver's license.